### PR TITLE
Only use 64-bit dir when Python is 64-bit

### DIFF
--- a/archook/archook.py
+++ b/archook/archook.py
@@ -47,7 +47,11 @@ def get_arcpy():
 
   # First check if we have a bin64 directory - this exists when arcgis is 64bit
   bin_dir = path.join(install_dir, "bin64")
-  if not path.exists(bin_dir):
+  
+  # check if we are using a 64-bit version of Python
+  is_64bits = sys.maxsize > 2**32
+  
+  if not path.exists(bin_dir) or is_64bits == False:
     # Fall back to regular 'bin' dir otherwise.
     bin_dir = path.join(install_dir, "bin")
 


### PR DESCRIPTION
Otherwise tries to use 64 bit version with 32-bit Python resulting in:

>>> import arcpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files (x86)\ArcGIS\Desktop10.4\arcpy\arcpy\__init__.py", line
 22, in <module>
    from arcpy.geoprocessing import gp
  File "C:\Program Files (x86)\ArcGIS\Desktop10.4\arcpy\arcpy\geoprocessing\__in
it__.py", line 14, in <module>
    from _base import *
  File "C:\Program Files (x86)\ArcGIS\Desktop10.4\arcpy\arcpy\geoprocessing\_bas
e.py", line 14, in <module>
    import arcgisscripting
ImportError: DLL load failed: %1 is not a valid Win32 application.